### PR TITLE
Add command descriptions

### DIFF
--- a/command/list.go
+++ b/command/list.go
@@ -15,7 +15,7 @@ func (c *ListCommand) Run(args []string) int {
 }
 
 func (c *ListCommand) Synopsis() string {
-	return ""
+	return "List mapping of <login_name> and <github_username>"
 }
 
 func (c *ListCommand) Help() string {

--- a/command/register.go
+++ b/command/register.go
@@ -15,7 +15,7 @@ func (c *RegisterCommand) Run(args []string) int {
 }
 
 func (c *RegisterCommand) Synopsis() string {
-	return ""
+	return "Register LoginName and GitHubUsername mapping"
 }
 
 func (c *RegisterCommand) Help() string {

--- a/command/to-github-name.go
+++ b/command/to-github-name.go
@@ -15,7 +15,7 @@ func (c *ToGithubNameCommand) Run(args []string) int {
 }
 
 func (c *ToGithubNameCommand) Synopsis() string {
-	return ""
+	return "Get <github_username> from <login_name>"
 }
 
 func (c *ToGithubNameCommand) Help() string {


### PR DESCRIPTION
## WHY

Add command descriptions

## WHAT

Add description based on https://github.com/wantedly/github-username-converter/pull/1

### result
```
usage: github-username-converter [--version] [--help] <command> [<args>]

Available commands are:
    list              List mapping of <login_name> and <github_username>
    register          Get <github_username> from <login_name>
    to-github-name    Register LoginName and GitHubUsername mapping
    version           Print github-username-converter version and quit
```