### PR TITLE
Add Makefile with basic functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+NAME := github-username-converter
+VERSION := 0.1.0
+REVISION := $(shell git rev-parse --short HEAD)
+
+LDFLAGS := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\""
+
+.DEFAULT_GOAL := bin/$(NAME)
+
+bin/$(NAME):
+	go build $(LDFLAGS) -o bin/$(NAME)
+
+.PHONY: clean
+clean:
+	rm -rf bin/*
+	rm -rf dist/*
+	rm -rf vendor/*
+
+.PHONY: install
+install:
+	go install $(LDFLAGS)


### PR DESCRIPTION
## WHY

Make development easier.

## WHAT

Add Makefile with `clean` and `install`
based on [Makefile of slack-mention-converter](https://github.com/wantedly/slack-mention-converter/blob/master/Makefile)
glide related tasks were ignored because we don't need this for now.