### PR TITLE
Rename to developers-account-mapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-github-username-converter
+developers-account-mapper
 *.test
 /vendor

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME := github-username-converter
+NAME := developers-account-mapper
 VERSION := 0.1.0
 REVISION := $(shell git rev-parse --short HEAD)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# github-username-converter
+# developers-account-mapper
 
 
 
@@ -11,12 +11,12 @@
 To install, use `go get`:
 
 ```bash
-$ go get -d github.com/wantedly/github-username-converter
+$ go get -d github.com/wantedly/developers-account-mapper
 ```
 
 ## Contribution
 
-1. Fork ([https://github.com/wantedly/github-username-converter/fork](https://github.com/wantedly/github-username-converter/fork))
+1. Fork ([https://github.com/wantedly/developers-account-mapper/fork](https://github.com/wantedly/developers-account-mapper/fork))
 1. Create a feature branch
 1. Commit your changes
 1. Rebase your local changes against the master branch

--- a/cli.go
+++ b/cli.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/mitchellh/cli"
-	"github.com/wantedly/github-username-converter/command"
+	"github.com/wantedly/developers-account-mapper/command"
 )
 
 func Run(args []string) int {

--- a/commands.go
+++ b/commands.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/mitchellh/cli"
-	"github.com/wantedly/github-username-converter/command"
+	"github.com/wantedly/developers-account-mapper/command"
 )
 
 func Commands(meta *command.Meta) map[string]cli.CommandFactory {

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,3 @@
-package: github.com/wantedly/github-username-converter
+package: github.com/wantedly/developers-account-mapper
 import:
 - package: github.com/mitchellh/cli

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package main
 
-const Name string = "github-username-converter"
+const Name string = "developers-account-mapper"
 const Version string = "0.1.0"
 
 // GitCommit describes latest commit hash.


### PR DESCRIPTION
## WHY

We want to merge https://github.com/wantedly/slack-mention-converter and this project.
Here are the reasons
+ slack-mention-converter has outdated structure in it
+ general account mapper is more maintainable than username converters for specific services.
+ after merged, we don't need to maintain more than one DynamoDB table
+ this project is almost at scratch, we can reuse code in this repository for the merged converter

## WHAT

Rename to developers-account-mapper

After this PR is merged, I will rename this repository.