### PR TITLE
Add register and list command

### DIFF
--- a/command/list.go
+++ b/command/list.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"strings"
-	"github.com/wantedly/github-username-converter/store"
+	"github.com/wantedly/developers-account-mapper/store"
 	"log"
 	"fmt"
 )

--- a/command/list.go
+++ b/command/list.go
@@ -2,9 +2,10 @@ package command
 
 import (
 	"strings"
-	"github.com/wantedly/developers-account-mapper/store"
 	"log"
 	"fmt"
+
+	"github.com/wantedly/developers-account-mapper/store"
 )
 
 type ListCommand struct {

--- a/command/list.go
+++ b/command/list.go
@@ -2,6 +2,9 @@ package command
 
 import (
 	"strings"
+	"github.com/wantedly/github-username-converter/store"
+	"log"
+	"fmt"
 )
 
 type ListCommand struct {
@@ -9,7 +12,16 @@ type ListCommand struct {
 }
 
 func (c *ListCommand) Run(args []string) int {
-	// Write your code here
+	s := store.NewDynamoDB()
+	users, err := s.ListUsers()
+
+	if err != nil {
+		log.Println(err)
+		return 1
+	}
+	for _, user := range users {
+		fmt.Println(user)
+	}
 
 	return 0
 }

--- a/command/register.go
+++ b/command/register.go
@@ -33,7 +33,7 @@ func (c *RegisterCommand) Run(args []string) int {
 		log.Println(err)
 		return 1
 	}
-	fmt.Printf("user %v added.\n", user)
+	fmt.Printf("user %q added.\n", user)
 
 	return 0
 }

--- a/command/register.go
+++ b/command/register.go
@@ -29,8 +29,7 @@ func (c *RegisterCommand) Run(args []string) int {
 	s := store.NewDynamoDB()
 
 	user := models.NewUser(loginName, githubUsername)
-	err := s.AddUser(user)
-	if err != nil {
+	if err := s.AddUser(user); err != nil {
 		log.Println(err)
 		return 1
 	}

--- a/command/register.go
+++ b/command/register.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"log"
 	"fmt"
-	"github.com/wantedly/github-username-converter/store"
-	"github.com/wantedly/github-username-converter/models"
+	"github.com/wantedly/developers-account-mapper/store"
+	"github.com/wantedly/developers-account-mapper/models"
 )
 
 type RegisterCommand struct {

--- a/command/register.go
+++ b/command/register.go
@@ -2,6 +2,11 @@ package command
 
 import (
 	"strings"
+	"os"
+	"log"
+	"fmt"
+	"github.com/wantedly/github-username-converter/store"
+	"github.com/wantedly/github-username-converter/models"
 )
 
 type RegisterCommand struct {
@@ -9,7 +14,27 @@ type RegisterCommand struct {
 }
 
 func (c *RegisterCommand) Run(args []string) int {
-	// Write your code here
+	var loginName, githubUsername string
+	if len(args) == 1 {
+		loginName = os.Getenv("USER")
+		githubUsername = args[0]
+	} else if len(args) == 2 {
+		loginName = args[0]
+		githubUsername = args[1]
+	} else {
+		log.Println(c.Help())
+		return 1
+	}
+
+	s := store.NewDynamoDB()
+
+	user := models.NewUser(loginName, githubUsername)
+	err := s.AddUser(user)
+	if err != nil {
+		log.Println(err)
+		return 1
+	}
+	fmt.Printf("user %v added.\n", user)
 
 	return 0
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,44 @@
-hash: 6e8c14804bceb23e33070de8e837bdce6dc78d41fe61d49000b24941f074c168
-updated: 2016-12-15T10:53:17.518119654+09:00
+hash: 8b58e376a349f31d7b936d4efcc1e44dc8e97d153deed4a6637eae545cf0b948
+updated: 2016-12-19T15:52:09.195272853+09:00
 imports:
 - name: github.com/armon/go-radix
   version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
+- name: github.com/aws/aws-sdk-go
+  version: 0df2a7ae7e82d2643e4a8fed1b2e36a1cf0580bc
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/endpoints
+  - aws/request
+  - aws/service/dynamodb
+  - aws/session
+  - aws/signer/v4
+  - private/protocol
+  - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/xml/xmlutil
+  - private/waiter
+  - service/dynamodb
+  - service/sts
 - name: github.com/bgentry/speakeasy
   version: 36e9cfdd690967f4f690c6edcc9ffacd006014a0
+- name: github.com/go-ini/ini
+  version: 2ba15ac2dc9cdf88c110ec2dc0ced7fa45f5678c
+- name: github.com/jmespath/go-jmespath
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/mattn/go-isatty
   version: 56b76bdf51f7708750eac80fa38b952bb9f32639
 - name: github.com/mitchellh/cli

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,8 @@
 package: github.com/wantedly/github-username-converter
 import:
 - package: github.com/mitchellh/cli
+- package: github.com/aws/aws-sdk-go
+  subpackages:
+  - aws
+  - aws/session
+  - aws/service/dynamodb

--- a/models/user.go
+++ b/models/user.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"fmt"
+)
+
+// User stores login user name and GitHub username
+type User struct {
+	LoginName string
+	GitHubUsername string
+}
+
+// NewUser creates new User instance
+func NewUser(loginName string, githubUsername string) *User {
+	return &User{
+		LoginName: loginName,
+		GitHubUsername: githubUsername,
+	}
+}
+
+func (u *User) String() string {
+	return fmt.Sprintf("%v:@%v", u.LoginName, u.GitHubUsername)
+}

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -40,3 +40,19 @@ func (d *DynamoDB) ListUsers() ([]*models.User, error) {
 	return users, nil
 }
 
+func (d *DynamoDB) AddUser(user *models.User) (error) {
+	_, err := d.db.PutItem(&dynamodb.PutItemInput{
+		TableName: aws.String(githubUsersTable),
+		Item: map[string]*dynamodb.AttributeValue{
+			"LoginName": {
+				S: aws.String(user.LoginName),
+			},
+			"GitHubUsername": {
+				S: aws.String(user.GitHubUsername),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+}

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	githubUsersTable = "GitHubUsers"
+	accountMapTable = "GitHubUsers"
 )
 
 type DynamoDB struct {
@@ -25,7 +25,7 @@ func NewDynamoDB() *DynamoDB {
 
 func (d *DynamoDB) ListUsers() ([]*models.User, error) {
 	resp, err := d.db.Scan(&dynamodb.ScanInput{
-		TableName: aws.String(githubUsersTable),
+		TableName: aws.String(accountMapTable),
 	})
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (d *DynamoDB) ListUsers() ([]*models.User, error) {
 
 func (d *DynamoDB) AddUser(user *models.User) (error) {
 	_, err := d.db.PutItem(&dynamodb.PutItemInput{
-		TableName: aws.String(githubUsersTable),
+		TableName: aws.String(accountMapTable),
 		Item: map[string]*dynamodb.AttributeValue{
 			"LoginName": {
 				S: aws.String(user.LoginName),

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -34,7 +34,7 @@ func (d *DynamoDB) ListUsers() ([]*models.User, error) {
 	var users []*models.User
 
 	for _, item := range resp.Items {
-		users = append(users, models.NewUser(*item["LoginName"].S, *item["GitHubUSername"].S))
+		users = append(users, models.NewUser(*item["LoginName"].S, *item["GitHubUsername"].S))
 	}
 
 	return users, nil

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -4,7 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/wantedly/github-username-converter/models"
+	"github.com/wantedly/developers-account-mapper/models"
 )
 
 const (

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -1,0 +1,42 @@
+package store
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/wantedly/github-username-converter/models"
+)
+
+const (
+	githubUsersTable = "GitHubUsers"
+)
+
+type DynamoDB struct {
+	db *dynamodb.DynamoDB
+}
+
+func NewDynamoDB() *DynamoDB {
+	db := dynamodb.New(session.New(&aws.Config{}))
+
+	return &DynamoDB{
+		db: db,
+	}
+}
+
+func (d *DynamoDB) ListUsers() ([]*models.User, error) {
+	resp, err := d.db.Scan(&dynamodb.ScanInput{
+		TableName: aws.String(githubUsersTable),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var users []*models.User
+
+	for _, item := range resp.Items {
+		users = append(users, models.NewUser(*item["LoginName"].S, *item["GitHubUSername"].S))
+	}
+
+	return users, nil
+}
+

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	accountMapTable = "GitHubUsers"
+	accountMapTable = "DevelopersAccountMap"
 )
 
 type DynamoDB struct {

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -55,4 +55,6 @@ func (d *DynamoDB) AddUser(user *models.User) (error) {
 	if err != nil {
 		return err
 	}
+
+	return nil
 }


### PR DESCRIPTION
## WHY

We need register and list command to read and write our account names.

## WHAT

- [x] Add DynamoDB model with `list` and `add` capability
- [x] Add User model with GitHub username
- [x] Implement `register` and `list` command using those above

### Test
```console
potsbo@quorra-INS-% envchain wtd ./bin/developers-account-mapper register potsbo potsbo
user potsbo:@potsbo added.
potsbo@quorra-INS-% envchain wtd ./bin/developers-account-mapper list
potsbo:@potsbo
```

We do need automatic test and write ones.
Planned to introduce in a later PR.
This is why I haven't done anything on `*_test.go`