### PR TITLE
Introduce Slack Integration

### DIFF
--- a/command/list.go
+++ b/command/list.go
@@ -28,7 +28,7 @@ func (c *ListCommand) Run(args []string) int {
 }
 
 func (c *ListCommand) Synopsis() string {
-	return "List mapping of <login_name> and <github_username>"
+	return "List mapping of <login_name> and mapped accounts"
 }
 
 func (c *ListCommand) Help() string {

--- a/command/register.go
+++ b/command/register.go
@@ -47,7 +47,7 @@ func (c *RegisterCommand) Run(args []string) int {
 }
 
 func (c *RegisterCommand) Synopsis() string {
-	return "Register LoginName and GitHubUsername mapping"
+	return "Register LoginName and other accounts mapping"
 }
 
 func (c *RegisterCommand) Help() string {

--- a/command/register.go
+++ b/command/register.go
@@ -14,13 +14,15 @@ type RegisterCommand struct {
 }
 
 func (c *RegisterCommand) Run(args []string) int {
-	var loginName, githubUsername string
-	if len(args) == 1 {
+	var loginName, githubUsername, slackUsername string
+	if len(args) == 2 {
 		loginName = os.Getenv("USER")
 		githubUsername = args[0]
-	} else if len(args) == 2 {
+		slackUsername  = args[1]
+	} else if len(args) == 3 {
 		loginName = args[0]
 		githubUsername = args[1]
+		slackUsername = args[2]
 	} else {
 		log.Println(c.Help())
 		return 1
@@ -28,7 +30,12 @@ func (c *RegisterCommand) Run(args []string) int {
 
 	s := store.NewDynamoDB()
 
-	user := models.NewUser(loginName, githubUsername)
+	user := models.NewUser(loginName, githubUsername, slackUsername, "")
+	user, err := user.RetrieveSlackUserId()
+	if err != nil {
+		log.Println(err)
+		return 1
+	}
 	if err := s.AddUser(user); err != nil {
 		log.Println(err)
 		return 1

--- a/command/register.go
+++ b/command/register.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"log"
 	"fmt"
+
 	"github.com/wantedly/developers-account-mapper/store"
 	"github.com/wantedly/developers-account-mapper/models"
 )

--- a/command/register.go
+++ b/command/register.go
@@ -32,7 +32,7 @@ func (c *RegisterCommand) Run(args []string) int {
 	s := store.NewDynamoDB()
 
 	user := models.NewUser(loginName, githubUsername, slackUsername, "")
-	user, err := user.RetrieveSlackUserId()
+	err := user.RetrieveSlackUserId()
 	if err != nil {
 		log.Println(err)
 		return 1

--- a/models/user.go
+++ b/models/user.go
@@ -24,17 +24,12 @@ func NewUser(loginName string, githubUsername string, slackUsername string, slac
 	}
 }
 
-func (u *User) SetSlackUserId(newId string) *User {
-	u.SlackUserId = newId
-	return u
-}
-
 func (u *User) RetrieveSlackUserId() error {
 	nameIdMap, err := services.SlackUserList()
 	if err != nil {
 		return err
 	}
-	u.SetSlackUserId(nameIdMap[u.SlackUsername])
+	u.SlackUserId = nameIdMap[u.SlackUsername]
 	return nil
 }
 

--- a/models/user.go
+++ b/models/user.go
@@ -29,13 +29,13 @@ func (u *User) SetSlackUserId(newId string) *User {
 	return u
 }
 
-func (u *User) RetrieveSlackUserId() (*User, error) {
+func (u *User) RetrieveSlackUserId() error {
 	nameIdMap, err := services.SlackUserList()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	u.SetSlackUserId(nameIdMap[u.SlackUsername])
-	return u, nil
+	return nil
 }
 
 func (u *User) String() string {

--- a/models/user.go
+++ b/models/user.go
@@ -2,24 +2,45 @@ package models
 
 import (
 	"fmt"
+
+	"github.com/wantedly/developers-account-mapper/services"
 )
 
 // User stores login user name and GitHub username
 type User struct {
-	LoginName string
+	LoginName      string
 	GitHubUsername string
-	SlackUsername string
+	SlackUsername  string
+	SlackUserId    string
 }
 
 // NewUser creates new User instance
-func NewUser(loginName string, githubUsername string, slackUsername string) *User {
+func NewUser(loginName string, githubUsername string, slackUsername string, slackUserId string) *User {
 	return &User{
 		LoginName: loginName,
 		GitHubUsername: githubUsername,
 		SlackUsername: slackUsername,
+		SlackUserId: "",
 	}
 }
 
+func (u *User) SetSlackUserId(newId string) *User {
+	u.SlackUserId = newId
+	return u
+}
+
+func (u *User) RetrieveSlackUserId() (*User, error) {
+	nameIdMap, err := services.SlackUserList()
+	if err != nil {
+		return nil, err
+	}
+	u.SetSlackUserId(nameIdMap[u.SlackUsername])
+	return u, nil
+}
+
 func (u *User) String() string {
-	return fmt.Sprintf("%v:@%v", u.LoginName, u.GitHubUsername)
+	if u.SlackUserId == "" {
+		u.RetrieveSlackUserId()
+	}
+	return fmt.Sprintf("%v:@%v:<@%v:%v>", u.LoginName, u.GitHubUsername, u.SlackUsername, u.SlackUserId)
 }

--- a/models/user.go
+++ b/models/user.go
@@ -6,7 +6,7 @@ import (
 	"github.com/wantedly/developers-account-mapper/services"
 )
 
-// User stores login user name and GitHub username
+// User stores login user name and accounts information
 type User struct {
 	LoginName      string
 	GitHubUsername string

--- a/models/user.go
+++ b/models/user.go
@@ -8,13 +8,15 @@ import (
 type User struct {
 	LoginName string
 	GitHubUsername string
+	SlackUsername string
 }
 
 // NewUser creates new User instance
-func NewUser(loginName string, githubUsername string) *User {
+func NewUser(loginName string, githubUsername string, slackUsername string) *User {
 	return &User{
 		LoginName: loginName,
 		GitHubUsername: githubUsername,
+		SlackUsername: slackUsername,
 	}
 }
 

--- a/models/user.go
+++ b/models/user.go
@@ -35,7 +35,10 @@ func (u *User) RetrieveSlackUserId() error {
 
 func (u *User) String() string {
 	if u.SlackUserId == "" {
-		u.RetrieveSlackUserId()
+		err := u.RetrieveSlackUserId()
+		if err != nil {
+			return fmt.Sprintf("%v", err)
+		}
 	}
 	return fmt.Sprintf("%v:@%v:<@%v:%v>", u.LoginName, u.GitHubUsername, u.SlackUsername, u.SlackUserId)
 }

--- a/models/user.go
+++ b/models/user.go
@@ -33,12 +33,12 @@ func (u *User) RetrieveSlackUserId() error {
 	return nil
 }
 
-func (u *User) String() string {
+func (u *User) String() (string, error) {
 	if u.SlackUserId == "" {
 		err := u.RetrieveSlackUserId()
 		if err != nil {
-			return fmt.Sprintf("%v", err)
+			return nil, err
 		}
 	}
-	return fmt.Sprintf("%v:@%v:<@%v:%v>", u.LoginName, u.GitHubUsername, u.SlackUsername, u.SlackUserId)
+	return fmt.Sprintf("%v:@%v:<@%v:%v>", u.LoginName, u.GitHubUsername, u.SlackUsername, u.SlackUserId), nil
 }

--- a/models/user.go
+++ b/models/user.go
@@ -20,7 +20,7 @@ func NewUser(loginName string, githubUsername string, slackUsername string, slac
 		LoginName: loginName,
 		GitHubUsername: githubUsername,
 		SlackUsername: slackUsername,
-		SlackUserId: "",
+		SlackUserId: slackUserId,
 	}
 }
 

--- a/services/slack_api.go
+++ b/services/slack_api.go
@@ -34,10 +34,13 @@ func SlackUserList() (map[string]string, error){
 
 	users := make(map[string]string)
 	for i := 0; i < len(arr); i++ {
-		id, idErr := jq.String("members", strconv.Itoa(i), "id")
-		name, nameErr := jq.String("members", strconv.Itoa(i), "name")
-		if idErr != nil && nameErr != nil {
-			return nil, idErr || nameErr
+		id, err := jq.String("members", strconv.Itoa(i), "id")
+		if err != nil {
+			return nil, err
+		}
+		name, err := jq.String("members", strconv.Itoa(i), "name")
+		if err != nil {
+			return nil, err
 		}
 		users[name] = id
 	}

--- a/services/slack_api.go
+++ b/services/slack_api.go
@@ -34,8 +34,11 @@ func SlackUserList() (map[string]string, error){
 
 	users := make(map[string]string)
 	for i := 0; i < len(arr); i++ {
-		id, _ := jq.String("members", strconv.Itoa(i), "id")
-		name, _ := jq.String("members", strconv.Itoa(i), "name")
+		id, idErr := jq.String("members", strconv.Itoa(i), "id")
+		name, nameErr := jq.String("members", strconv.Itoa(i), "name")
+		if idErr != nil && nameErr != nil {
+			return nil, idErr || nameErr
+		}
 		users[name] = id
 	}
 	return users, err

--- a/services/slack_api.go
+++ b/services/slack_api.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"encoding/json"
-	"github.com/jmoiron/jsonq"
 	"strconv"
+
+	"github.com/jmoiron/jsonq"
 )
 
 const (

--- a/services/slack_api.go
+++ b/services/slack_api.go
@@ -1,0 +1,32 @@
+package services
+
+import (
+	"os"
+	"fmt"
+	"net/http"
+	"encoding/json"
+	"github.com/jmoiron/jsonq"
+)
+
+const (
+	slackUserListURL = "https://slack.com/api/users.list"
+)
+
+func SlackUserList() ([]interface{}){
+	if token := os.Getenv("SLACK_API_TOKEN"); token == "" {
+		return nil, fmt.Errorf("You need to pass SLACK_API_TOKEN as environment variable")
+	}
+	requestURL := slackUserListURL + "?token=" + token
+	resp, err := http.Get(requestURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data := map[string]interface{}{}
+	dec := json.NewDecoder(resp.Body)
+	dec.Decode(&data)
+	jq := jsonq.NewQuery(data)
+	arr, err := jq.Array("members")
+	return arr, err
+}

--- a/services/slack_api.go
+++ b/services/slack_api.go
@@ -6,14 +6,16 @@ import (
 	"net/http"
 	"encoding/json"
 	"github.com/jmoiron/jsonq"
+	"strconv"
 )
 
 const (
 	slackUserListURL = "https://slack.com/api/users.list"
 )
 
-func SlackUserList() ([]interface{}){
-	if token := os.Getenv("SLACK_API_TOKEN"); token == "" {
+func SlackUserList() (map[string]string, error){
+	token := os.Getenv("SLACK_API_TOKEN")
+	if token == "" {
 		return nil, fmt.Errorf("You need to pass SLACK_API_TOKEN as environment variable")
 	}
 	requestURL := slackUserListURL + "?token=" + token
@@ -28,5 +30,12 @@ func SlackUserList() ([]interface{}){
 	dec.Decode(&data)
 	jq := jsonq.NewQuery(data)
 	arr, err := jq.Array("members")
-	return arr, err
+
+	users := make(map[string]string)
+	for i := 0; i < len(arr); i++ {
+		id, _ := jq.String("members", strconv.Itoa(i), "id")
+		name, _ := jq.String("members", strconv.Itoa(i), "name")
+		users[name] = id
+	}
+	return users, err
 }

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -34,7 +34,7 @@ func (d *DynamoDB) ListUsers() ([]*models.User, error) {
 	var users []*models.User
 
 	for _, item := range resp.Items {
-		users = append(users, models.NewUser(*item["LoginName"].S, *item["GitHubUsername"].S, *item["SlackUsername"].S, ""))
+		users = append(users, models.NewUser(*item["LoginName"].S, *item["GitHubUsername"].S, *item["SlackUsername"].S, *item["SlackUserId"]))
 	}
 
 	return users, nil

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -34,7 +34,7 @@ func (d *DynamoDB) ListUsers() ([]*models.User, error) {
 	var users []*models.User
 
 	for _, item := range resp.Items {
-		users = append(users, models.NewUser(*item["LoginName"].S, *item["GitHubUsername"].S, *item["SlackUsername"].S, *item["SlackUserId"]))
+		users = append(users, models.NewUser(*item["LoginName"].S, *item["GitHubUsername"].S, *item["SlackUsername"].S, *item["SlackUserId"].S))
 	}
 
 	return users, nil

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -50,6 +50,12 @@ func (d *DynamoDB) AddUser(user *models.User) (error) {
 			"GitHubUsername": {
 				S: aws.String(user.GitHubUsername),
 			},
+			"SlackUsername": {
+				S: aws.String(user.SlackUsername),
+			},
+			"SlackUserId": {
+				S: aws.String(user.SlackUserId),
+			},
 		},
 	})
 	if err != nil {

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -58,9 +58,5 @@ func (d *DynamoDB) AddUser(user *models.User) (error) {
 			},
 		},
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -34,7 +34,7 @@ func (d *DynamoDB) ListUsers() ([]*models.User, error) {
 	var users []*models.User
 
 	for _, item := range resp.Items {
-		users = append(users, models.NewUser(*item["LoginName"].S, *item["GitHubUsername"].S))
+		users = append(users, models.NewUser(*item["LoginName"].S, *item["GitHubUsername"].S, *item["SlackUsername"].S, ""))
 	}
 
 	return users, nil


### PR DESCRIPTION
## WHY

Developers need to map their Slack accounts and GitHub ones.

## WHAT

Add Slack account map ability
- [x] Add Slack service to fetch SlackID(not username)
- [x] Store Slack account information DynamoDB

## TEST
```console
potsbo@Shimpeis-MacBook-Pro-INS-% make && envchain wtd ./bin/developers-account-mapper register potsbo potsbo shimpei
go build -ldflags="-s -w -X \"main.Version=0.1.0\" -X \"main.Revision=ef04633\"" -o bin/developers-account-mapper
user "potsbo:@potsbo:<@shimpei:<CONSEALED>>" added.
potsbo@Shimpeis-MacBook-Pro-INS-% make && envchain wtd ./bin/developers-account-mapper list
make: `bin/developers-account-mapper' is up to date.
potsbo:@potsbo:<@shimpei:<CONSEALED>>
```

## NOTE

- Test is still not implemented, which has to be done
