### PR TITLE
Let user return envs slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ NAME := developers-account-mapper
 VERSION := 0.1.0
 REVISION := $(shell git rev-parse --short HEAD)
 
-SRCS    := $(shell find . -type f -name '*.go')
+SRCS           := $(shell find . -type f -name '*.go')
+SRCS_NO_VENDOR := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 LDFLAGS := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\""
 
@@ -28,6 +29,10 @@ endif
 .PHONY: test
 test:
 	go test -v `glide novendor`
+
+.PHONY: gofmt
+gofmt: $(SRCS_NO_VENDOR)
+	gofmt -s -l -w $(SRCS_NO_VENDOR)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test:
 
 .PHONY: gofmt
 gofmt: $(SRCS_NO_VENDOR)
-	gofmt -s -l -w $(SRCS_NO_VENDOR)
+	gofmt -s -w $(SRCS_NO_VENDOR)
 
 .PHONY: clean
 clean:

--- a/command/list.go
+++ b/command/list.go
@@ -1,9 +1,9 @@
 package command
 
 import (
-	"strings"
-	"log"
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/wantedly/developers-account-mapper/store"
 )

--- a/command/register.go
+++ b/command/register.go
@@ -1,13 +1,13 @@
 package command
 
 import (
-	"strings"
-	"os"
-	"log"
 	"fmt"
+	"log"
+	"os"
+	"strings"
 
-	"github.com/wantedly/developers-account-mapper/store"
 	"github.com/wantedly/developers-account-mapper/models"
+	"github.com/wantedly/developers-account-mapper/store"
 )
 
 type RegisterCommand struct {
@@ -19,7 +19,7 @@ func (c *RegisterCommand) Run(args []string) int {
 	if len(args) == 2 {
 		loginName = os.Getenv("USER")
 		githubUsername = args[0]
-		slackUsername  = args[1]
+		slackUsername = args[1]
 	} else if len(args) == 3 {
 		loginName = args[0]
 		githubUsername = args[1]

--- a/models/user.go
+++ b/models/user.go
@@ -24,6 +24,10 @@ func NewUser(loginName string, githubUsername string, slackUsername string, slac
 	}
 }
 
+func (u *User) Envs() []string {
+	return []string{}
+}
+
 func (u *User) SlackMention() string {
 	return fmt.Sprintf("<@%v|%v>", u.SlackUserId, u.SlackUsername)
 }

--- a/models/user.go
+++ b/models/user.go
@@ -24,6 +24,10 @@ func NewUser(loginName string, githubUsername string, slackUsername string, slac
 	}
 }
 
+func (u *User) SlackMention() string {
+	return fmt.Sprintf("<@%v|%v>", u.SlackUserId, u.SlackUsername)
+}
+
 func (u *User) RetrieveSlackUserId() error {
 	nameIdMap, err := services.SlackUserList()
 	if err != nil {

--- a/models/user.go
+++ b/models/user.go
@@ -25,7 +25,10 @@ func NewUser(loginName string, githubUsername string, slackUsername string, slac
 }
 
 func (u *User) Envs() []string {
-	return []string{}
+	return []string{
+		fmt.Sprintf("GITHUB_USERNAME=%s", u.GitHubUsername),
+		fmt.Sprintf("SLACK_MENTION=%s", u.SlackMention()),
+	}
 }
 
 func (u *User) SlackMention() string {

--- a/models/user.go
+++ b/models/user.go
@@ -17,10 +17,10 @@ type User struct {
 // NewUser creates new User instance
 func NewUser(loginName string, githubUsername string, slackUsername string, slackUserId string) *User {
 	return &User{
-		LoginName: loginName,
+		LoginName:      loginName,
 		GitHubUsername: githubUsername,
-		SlackUsername: slackUsername,
-		SlackUserId: slackUserId,
+		SlackUsername:  slackUsername,
+		SlackUserId:    slackUserId,
 	}
 }
 

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -33,13 +34,7 @@ func TestEnvs(t *testing.T) {
 	}
 	actual := user.Envs()
 
-	if len(actual) != len(expect) {
-		t.Fatalf("%v does not much to expected: %v", len(actual), len(expect))
-	}
-
-	for i := range expect {
-		if expect[i] != actual[i] {
-			t.Fatalf("%v does not much to expected: %v", actual, expect)
-		}
+	if !reflect.DeepEqual(actual, expect) {
+		t.Fatalf("%v does not much to expected: %v", actual, expect)
 	}
 }

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"testing"
+)
+
+func TestSlackMention(t *testing.T) {
+	user := &User {
+		LoginName: "loginName",
+		GitHubUsername: "github_user",
+		SlackUsername: "slack_user",
+		SlackUserId: "SLACKID",
+	}
+
+	expect := "<@SLACKID|slack_user>"
+	actual := user.SlackMention()
+
+	if actual != expect {
+		t.Fatalf("%v does not much to expected: %v", actual, expect)
+	}
+}

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 func SetUser() *User {
-	return &User {
-		LoginName: "loginName",
+	return &User{
+		LoginName:      "loginName",
 		GitHubUsername: "github_user",
-		SlackUsername: "slack_user",
-		SlackUserId: "SLACKID",
+		SlackUsername:  "slack_user",
+		SlackUserId:    "SLACKID",
 	}
 }
 

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -21,7 +21,7 @@ func TestSlackMention(t *testing.T) {
 	actual := user.SlackMention()
 
 	if actual != expect {
-		t.Fatalf("%v does not much to expected: %v", actual, expect)
+		t.Fatalf("%v does not match to expected: %v", actual, expect)
 	}
 }
 
@@ -35,6 +35,6 @@ func TestEnvs(t *testing.T) {
 	actual := user.Envs()
 
 	if !reflect.DeepEqual(actual, expect) {
-		t.Fatalf("%v does not much to expected: %v", actual, expect)
+		t.Fatalf("%v does not match to expected: %v", actual, expect)
 	}
 }

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -36,4 +36,10 @@ func TestEnvs(t *testing.T) {
 	if len(actual) != len(expect) {
 		t.Fatalf("%v does not much to expected: %v", len(actual), len(expect))
 	}
+
+	for i := range expect {
+		if expect[i] != actual[i] {
+			t.Fatalf("%v does not much to expected: %v", actual, expect)
+		}
+	}
 }

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -23,3 +23,17 @@ func TestSlackMention(t *testing.T) {
 		t.Fatalf("%v does not much to expected: %v", actual, expect)
 	}
 }
+
+func TestEnvs(t *testing.T) {
+	user := SetUser()
+
+	expect := []string{
+		"GITHUB_USERNAME=github_user",
+		"SLACK_MENTION=<@SLACKID|slack_user>",
+	}
+	actual := user.Envs()
+
+	if actual != expect {
+		t.Fatalf("%v does not much to expected: %v", actual, expect)
+	}
+}

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -33,7 +33,7 @@ func TestEnvs(t *testing.T) {
 	}
 	actual := user.Envs()
 
-	if actual != expect {
-		t.Fatalf("%v does not much to expected: %v", actual, expect)
+	if len(actual) != len(expect) {
+		t.Fatalf("%v does not much to expected: %v", len(actual), len(expect))
 	}
 }

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -4,13 +4,17 @@ import (
 	"testing"
 )
 
-func TestSlackMention(t *testing.T) {
-	user := &User {
+func SetUser() *User {
+	return &User {
 		LoginName: "loginName",
 		GitHubUsername: "github_user",
 		SlackUsername: "slack_user",
 		SlackUserId: "SLACKID",
 	}
+}
+
+func TestSlackMention(t *testing.T) {
+	user := SetUser()
 
 	expect := "<@SLACKID|slack_user>"
 	actual := user.SlackMention()

--- a/services/slack_api.go
+++ b/services/slack_api.go
@@ -1,10 +1,10 @@
 package services
 
 import (
-	"os"
+	"encoding/json"
 	"fmt"
 	"net/http"
-	"encoding/json"
+	"os"
 	"strconv"
 
 	"github.com/jmoiron/jsonq"
@@ -14,7 +14,7 @@ const (
 	slackUserListURL = "https://slack.com/api/users.list"
 )
 
-func SlackUserList() (map[string]string, error){
+func SlackUserList() (map[string]string, error) {
 	token := os.Getenv("SLACK_API_TOKEN")
 	if token == "" {
 		return nil, fmt.Errorf("You need to pass SLACK_API_TOKEN as environment variable")

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -87,11 +87,11 @@ func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {
 
 	var user *models.User
 	if len(resp.Item) == 1 {
-		user = &models.User {
+		user = &models.User{
 			LoginName:      loginName,
 			GitHubUsername: *resp.Item["GitHubUsername"].S,
-			SlackUserId: *resp.Item["SlackUserId"].S,
-			SlackUsername: *resp.Item["SlackUsername"].S,
+			SlackUserId:    *resp.Item["SlackUserId"].S,
+			SlackUsername:  *resp.Item["SlackUsername"].S,
 		}
 	} else {
 		return nil, fmt.Errorf("%s is not registered yet", loginName)

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -85,16 +85,15 @@ func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {
 		return nil, err
 	}
 
-	var user *models.User
-	if len(resp.Item) == 1 {
-		user = &models.User{
-			LoginName:      loginName,
-			GitHubUsername: *resp.Item["GitHubUsername"].S,
-			SlackUserId:    *resp.Item["SlackUserId"].S,
-			SlackUsername:  *resp.Item["SlackUsername"].S,
-		}
-	} else {
+	if len(resp.Item) != 1 {
 		return nil, fmt.Errorf("%s is not registered yet", loginName)
+	}
+
+	user := &models.User {
+		LoginName:      loginName,
+		GitHubUsername: *resp.Item["GitHubUsername"].S,
+		SlackUserId: *resp.Item["SlackUserId"].S,
+		SlackUsername: *resp.Item["SlackUsername"].S,
 	}
 
 	return user, nil

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -93,7 +93,6 @@ func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {
 			SlackUserId: *resp.Item["SlackUserId"].S,
 			SlackUsername: *resp.Item["SlackUsername"].S,
 		}
-		 *resp.Item["GitHubUsername"].S
 	} else {
 		return nil, fmt.Errorf("%s is not registered yet", loginName)
 	}

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -73,6 +73,8 @@ func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {
 		},
 		AttributesToGet: []*string{
 			aws.String("GitHubUsername"),
+			aws.String("SlackUsername"),
+			aws.String("SlackUserId"),
 		},
 		ConsistentRead: aws.Bool(true),
 	}
@@ -83,16 +85,17 @@ func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {
 		return nil, err
 	}
 
-	var gitHubUsername string
+	var user *models.User
 	if len(resp.Item) == 1 {
-		gitHubUsername = *resp.Item["GitHubUsername"].S
+		user = &models.User {
+			LoginName:      loginName,
+			GitHubUsername: resp.Item[0]["GitHubUsername"],
+			SlackUserId: resp.Item[0]["SlackUserId"],
+			SlackUsername: resp.Item[0]["SlackUsername"],
+		}
+		 *resp.Item["GitHubUsername"].S
 	} else {
 		return nil, fmt.Errorf("%s is not registered yet", loginName)
-	}
-
-	user := &models.User{
-		LoginName:      loginName,
-		GitHubUsername: gitHubUsername,
 	}
 
 	return user, nil

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -89,9 +89,9 @@ func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {
 	if len(resp.Item) == 1 {
 		user = &models.User {
 			LoginName:      loginName,
-			GitHubUsername: resp.Item[0]["GitHubUsername"],
-			SlackUserId: resp.Item[0]["SlackUserId"],
-			SlackUsername: resp.Item[0]["SlackUsername"],
+			GitHubUsername: *resp.Item["GitHubUsername"].S,
+			SlackUserId: *resp.Item["SlackUserId"].S,
+			SlackUsername: *resp.Item["SlackUsername"].S,
 		}
 		 *resp.Item["GitHubUsername"].S
 	} else {

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -89,11 +89,11 @@ func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {
 		return nil, fmt.Errorf("%s is not registered yet", loginName)
 	}
 
-	user := &models.User {
+	user := &models.User{
 		LoginName:      loginName,
 		GitHubUsername: *resp.Item["GitHubUsername"].S,
-		SlackUserId: *resp.Item["SlackUserId"].S,
-		SlackUsername: *resp.Item["SlackUsername"].S,
+		SlackUserId:    *resp.Item["SlackUserId"].S,
+		SlackUsername:  *resp.Item["SlackUsername"].S,
 	}
 
 	return user, nil


### PR DESCRIPTION
## WHY

in https://github.com/wantedly/developers-account-mapper/pull/13 env vars are rendered in exec command.
However, this should be handled by user model it self.

## WHAT

- [x] Implement Envs()
- [x] Add test for it