### PR TITLE
Fix registered check bug

### DIFF
--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -85,7 +85,7 @@ func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {
 		return nil, err
 	}
 
-	if len(resp.Item) != 1 {
+	if len(resp.Item) == 0 {
 		return nil, fmt.Errorf("%s is not registered yet", loginName)
 	}
 


### PR DESCRIPTION
## WHY

[GetItemOutput check at master](https://github.com/wantedly/developers-account-mapper/blob/ab142fc2049ee06a9a3299394c8a94b89445eb3a/store/dynamo_db.go#L88-L90) doesn't work when fetching more than one attributes.

`len(resp.Item) != 1` only works when storing only one attribute, and this caused an error.

## WHAT

Check with `len(resp.Item) == 0`

```console
potsbo@magi-INS-% make && envchain wtd bin/developers-account-mapper exec potsbo echo 'test'
make: `bin/developers-account-mapper' is up to date.
test
potsbo@magi-INS-% make && envchain wtd bin/developers-account-mapper exec foo echo 'test'
make: `bin/developers-account-mapper' is up to date.
2017/01/11 18:02:50 foo is not registered yet
```