### PR TITLE
Add release task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ cross-build:
 		done; \
 	done
 
+.PHONY: release
+release:
+	git checkout master
+	git tag $(VERSION)
+	git push origin $(VERSION)
+
 .PHONY: clean
 clean:
 	rm -rf bin/*


### PR DESCRIPTION
## WHY

Current release flow may cause human errors, for developers have to manually set and push a tag.

## WHAT

Introduce release task to automate this.

@dtan4 I don't know this is considered as a dirty work or not. I want your opinion.

This task was actually used to release v0.1.0
```console
potsbo@magi-INS-% make release
git checkout master
M	Makefile
Already on 'master'
Your branch is up-to-date with 'origin/master'.
git tag v0.1.0
git push origin v0.1.0
Total 0 (delta 0), reused 0 (delta 0)
To github.com:wantedly/developers-account-mapper
 * [new tag]         v0.1.0 -> v0.1.0
```