### PR TITLE
Accept only expected number of arguments

### DIFF
--- a/command/register.go
+++ b/command/register.go
@@ -54,7 +54,7 @@ func (c *RegisterCommand) Synopsis() string {
 func (c *RegisterCommand) Help() string {
 	helpText := `
 	This command accepts exactly 3 argments in following order
-	+ Login username: IAM username
+	+ IAM username
 	+ GitHub username
 	+ Slack username
 `

--- a/command/register.go
+++ b/command/register.go
@@ -53,10 +53,7 @@ func (c *RegisterCommand) Synopsis() string {
 
 func (c *RegisterCommand) Help() string {
 	helpText := `
-	This command accepts exactly 3 argments in following order
-	+ IAM username
-	+ GitHub username
-	+ Slack username
+usage: developers-account-mapper register <iam_username> <github_username> <slack username>
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/register.go
+++ b/command/register.go
@@ -53,7 +53,10 @@ func (c *RegisterCommand) Synopsis() string {
 
 func (c *RegisterCommand) Help() string {
 	helpText := `
-
+	This command accepts exactly 3 argments in following order
+	+ Login username: IAM username
+	+ GitHub username
+	+ Slack username
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/register.go
+++ b/command/register.go
@@ -20,7 +20,7 @@ func (c *RegisterCommand) Run(args []string) int {
 		githubUsername = args[1]
 		slackUsername = args[2]
 	} else {
-		log.Println(c.Help())
+		fmt.Println(c.Help())
 		return 1
 	}
 

--- a/command/register.go
+++ b/command/register.go
@@ -3,7 +3,6 @@ package command
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/wantedly/developers-account-mapper/models"
@@ -16,11 +15,7 @@ type RegisterCommand struct {
 
 func (c *RegisterCommand) Run(args []string) int {
 	var loginName, githubUsername, slackUsername string
-	if len(args) == 2 {
-		loginName = os.Getenv("USER")
-		githubUsername = args[0]
-		slackUsername = args[1]
-	} else if len(args) == 3 {
+	if len(args) == 3 {
 		loginName = args[0]
 		githubUsername = args[1]
 		slackUsername = args[2]


### PR DESCRIPTION
## WHY

Current register command uses `USER` env var when one argument is missing.
This has two cons, and no pros.
+ might cause results that users don't want.
+ `USER` might conflict, we should use uniq usernames like IAM username

## WHAT

+ Accept exactly three arguments
+ Add help text