### PR TITLE
Add delete feature

### DIFF
--- a/command/delete.go
+++ b/command/delete.go
@@ -1,0 +1,24 @@
+package command
+
+import (
+	"strings"
+)
+
+type DeleteCommand struct {
+	Meta
+}
+
+func (c *DeleteCommand) Run(args []string) int {
+	return 0
+}
+
+func (c *DeleteCommand) Synopsis() string {
+	return "Delete record with <login_name>"
+}
+
+func (c *DeleteCommand) Help() string {
+	helpText := `
+
+`
+	return strings.TrimSpace(helpText)
+}

--- a/command/delete.go
+++ b/command/delete.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"strings"
+
+	"github.com/wantedly/developers-account-mapper/store"
 )
 
 type DeleteCommand struct {
@@ -9,6 +11,11 @@ type DeleteCommand struct {
 }
 
 func (c *DeleteCommand) Run(args []string) int {
+	loginName := args[0]
+
+	s := store.NewDynamoDB()
+	s.DeleteUser(loginName)
+
 	return 0
 }
 

--- a/command/delete.go
+++ b/command/delete.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"log"
 	"strings"
 
 	"github.com/wantedly/developers-account-mapper/store"
@@ -14,7 +15,12 @@ func (c *DeleteCommand) Run(args []string) int {
 	loginName := args[0]
 
 	s := store.NewDynamoDB()
-	s.DeleteUser(loginName)
+	err := s.DeleteUser(loginName)
+
+	if err != nil {
+		log.Println(err)
+		return 1
+	}
 
 	return 0
 }

--- a/commands.go
+++ b/commands.go
@@ -17,6 +17,11 @@ func Commands(meta *command.Meta) map[string]cli.CommandFactory {
 				Meta: *meta,
 			}, nil
 		},
+		"delete": func() (cli.Command, error) {
+			return &command.DeleteCommand{
+				Meta: *meta,
+			}, nil
+		},
 		"exec": func() (cli.Command, error) {
 			return &command.ExecCommand{
 				Meta: *meta,

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -63,6 +63,10 @@ func (d *DynamoDB) AddUser(user *models.User) error {
 	return err
 }
 
+func (d *DynamoDB) DeleteUser(user *models.User) error {
+	return nil
+}
+
 func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {
 	params := &dynamodb.GetItemInput{
 		TableName: aws.String(accountMapTable),

--- a/store/dynamo_db.go
+++ b/store/dynamo_db.go
@@ -63,8 +63,19 @@ func (d *DynamoDB) AddUser(user *models.User) error {
 	return err
 }
 
-func (d *DynamoDB) DeleteUser(user *models.User) error {
-	return nil
+func (d *DynamoDB) DeleteUser(loginName string) error {
+	params := &dynamodb.DeleteItemInput{
+		TableName: aws.String(accountMapTable),
+		Key: map[string]*dynamodb.AttributeValue{
+			"LoginName": {
+				S: aws.String(loginName),
+			},
+		},
+	}
+
+	_, err := d.db.DeleteItem(params)
+
+	return err
 }
 
 func (d *DynamoDB) GetUserByLoginName(loginName string) (*models.User, error) {


### PR DESCRIPTION
## WHY

To use developers-account-mapper in production, we need delete feature.

## WHAT

Implemented.

```console
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper register shimpei potsbo shimpei
user "shimpei:@potsbo:<@shimpei:<omitted>>" added.
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper register dai dtan4 dai
user "dai:@dtan4:<@dai:<omitted>>" added.
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper list
&{dai dtan4 dai <omitted>}
&{shimpei potsbo shimpei <omitted>}
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper delete shimpei
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper list
&{dai dtan4 dai <omitted>}
```