### PR TITLE
Use same user summary format as register

### DIFF
--- a/command/list.go
+++ b/command/list.go
@@ -20,8 +20,14 @@ func (c *ListCommand) Run(args []string) int {
 		log.Println(err)
 		return 1
 	}
+
 	for _, user := range users {
-		fmt.Println(user)
+		userSummary, err := user.String()
+		if err != nil {
+			log.Println(err)
+			return 1
+		}
+		fmt.Println(userSummary)
 	}
 
 	return 0

--- a/models/user.go
+++ b/models/user.go
@@ -51,5 +51,5 @@ func (u *User) String() (string, error) {
 			return "", err
 		}
 	}
-	return fmt.Sprintf("%v:@%v:<@%v:%v>", u.LoginName, u.GitHubUsername, u.SlackUsername, u.SlackUserId), nil
+	return fmt.Sprintf("%v:@%v:%v", u.LoginName, u.GitHubUsername, u.SlackMention()), nil
 }


### PR DESCRIPTION
## WHY

The format to show users in `list` command is different from that of `register`

```console
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper register dai dtan4 dai
user "dai:@dtan4:<@dai:<omitted>>" added.
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper list
&{dai dtan4 dai <omitted>}
&{shimpei potsbo shimpei <omitted>}
```

## WHAT

Use same format.

```console
potsbo@magi-INS-% make && envchain wtd bin/developers-account-mapper list
go build -ldflags="-s -w -X \"main.Version=v0.1.0\" -X \"main.Revision=0d2c753\"" -o bin/developers-account-mapper
dai:@dtan4:<@dai:U02NG6NPT>
```