### PR TITLE
Use Envs in exec command

### DIFF
--- a/command/exec.go
+++ b/command/exec.go
@@ -37,7 +37,7 @@ func (c *ExecCommand) Run(args []string) int {
 	}
 
 	envs := os.Environ()
-	envs = append(envs, fmt.Sprintf("%s=%s", "GITHUB_USERNAME", user.GitHubUsername))
+	envs = append(envs, user.Envs()...)
 
 	execCmd := exec.Command(args[1], args[2:]...)
 	execCmd.Env = envs


### PR DESCRIPTION
## WHY

Setting env vars in list command is not good structure
This can be simplified with `Envs` implemented at [Let user return envs slice](https://github.com/wantedly/developers-account-mapper/pull/15)

## WHAT

Use `Envs`

### TEST
```console
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper register shimpei potsbo shimpei
user "shimpei:@potsbo:<@shimpei:U2YBNNR24>" added.
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper exec shimpei env
<omitted>
GITHUB_USERNAME=potsbo
SLACK_MENTION=<@U2YBNNR24|shimpei>
```