### PR TITLE
Fix version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REVISION       := $(shell git rev-parse --short HEAD)
 SRCS           := $(shell find . -type f -name '*.go')
 SRCS_NO_VENDOR := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-LDFLAGS        := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\""
+LDFLAGS        := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.GitCommit=$(REVISION)\""
 
 DIST_DIRS      := find * -type d -exec
 

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package main
 
 var Name string = "developers-account-mapper"
-var Version string = "0.1.0"
+var Version string
 
 // GitCommit describes latest commit hash.
 // This value is extracted by git command when building.

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package main
 
-const Name string = "developers-account-mapper"
-const Version string = "0.1.0"
+var Name string = "developers-account-mapper"
+var Version string = "0.1.0"
 
 // GitCommit describes latest commit hash.
 // This value is extracted by git command when building.

--- a/version.go
+++ b/version.go
@@ -2,8 +2,4 @@ package main
 
 var Name string = "developers-account-mapper"
 var Version string
-
-// GitCommit describes latest commit hash.
-// This value is extracted by git command when building.
-// To set this from outside, use go build -ldflags "-X main.GitCommit \"$(COMMIT)\""
 var GitCommit string


### PR DESCRIPTION
## WHY

`developers-account-mapper version` returns `0.1.0` even after bumped up to `v0.2.0`
These are reasons
- It seems `ldflags` does not work with constants
- We should modify `GitCommit` instead of `Revision`

## WHAT

- Use `var` for values to inject
- Use `GitCommit` to inject commit hash

```console
potsbo@magi-INS-% make && ./bin/developers-account-mapper version
go build -ldflags="-s -w -X \"main.Version=v0.2.0\" -X \"main.GitCommit=ef555d9\"" -o bin/developers-account-mapper
developers-account-mapper version v0.2.0 (ef555d9)
```