### PR TITLE
Add SLACK_USER env var in exec command

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -28,6 +28,7 @@ func (u *User) Envs() []string {
 	return []string{
 		fmt.Sprintf("GITHUB_USERNAME=%s", u.GitHubUsername),
 		fmt.Sprintf("SLACK_MENTION=%s", u.SlackMention()),
+		fmt.Sprintf("SLACK_USER=%s", u.SlackUsername),
 	}
 }
 

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -31,6 +31,7 @@ func TestEnvs(t *testing.T) {
 	expect := []string{
 		"GITHUB_USERNAME=github_user",
 		"SLACK_MENTION=<@SLACKID|slack_user>",
+		"SLACK_USER=slack_user",
 	}
 	actual := user.Envs()
 


### PR DESCRIPTION
## WHY

`SLACK_USER` is more useful than `SLACK_MENTION`

## WHAT

Add `SLACK_USER` as env var in exec subcommand.