### PR TITLE
List prints with tab

### DIFF
--- a/command/list.go
+++ b/command/list.go
@@ -1,10 +1,10 @@
 package command
 
 import (
-	"fmt"
 	"log"
 	"strings"
 
+	"github.com/wantedly/developers-account-mapper/models"
 	"github.com/wantedly/developers-account-mapper/store"
 )
 
@@ -21,14 +21,7 @@ func (c *ListCommand) Run(args []string) int {
 		return 1
 	}
 
-	for _, user := range users {
-		userSummary, err := user.String()
-		if err != nil {
-			log.Println(err)
-			return 1
-		}
-		fmt.Println(userSummary)
-	}
+	models.PrintUsers(users)
 
 	return 0
 }

--- a/models/user.go
+++ b/models/user.go
@@ -24,6 +24,12 @@ func NewUser(loginName string, githubUsername string, slackUsername string, slac
 	}
 }
 
+const Headers = []string{
+	"AWS IAM",
+	"GITHUB",
+	"SLACK",
+}
+
 func (u *User) Envs() []string {
 	return []string{
 		fmt.Sprintf("GITHUB_USERNAME=%s", u.GitHubUsername),

--- a/models/user.go
+++ b/models/user.go
@@ -28,7 +28,7 @@ func NewUser(loginName string, githubUsername string, slackUsername string, slac
 }
 
 var UserHeaders = []string{
-	"AWS IAM",
+	"AWS-IAM",
 	"GITHUB",
 	"SLACK",
 }

--- a/models/user.go
+++ b/models/user.go
@@ -2,6 +2,9 @@ package models
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/wantedly/developers-account-mapper/services"
 )
@@ -24,10 +27,27 @@ func NewUser(loginName string, githubUsername string, slackUsername string, slac
 	}
 }
 
-const Headers = []string{
+var UserHeaders = []string{
 	"AWS IAM",
 	"GITHUB",
 	"SLACK",
+}
+
+func PrintUsers(users []*User) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+	fmt.Fprintln(w, strings.Join(UserHeaders, "\t"))
+	for _, user := range users {
+		fmt.Fprintln(w, strings.Join(user.Attributes(), "\t"))
+	}
+	w.Flush()
+}
+
+func (u *User) Attributes() []string {
+	return []string{
+		u.LoginName,
+		u.GitHubUsername,
+		u.SlackMention(),
+	}
 }
 
 func (u *User) Envs() []string {

--- a/models/user.go
+++ b/models/user.go
@@ -31,10 +31,11 @@ var UserHeaders = []string{
 	"AWS-IAM",
 	"GITHUB",
 	"SLACK",
+	"SLACK_MENTION",
 }
 
 func PrintUsers(users []*User) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, strings.Join(UserHeaders, "\t"))
 	for _, user := range users {
 		fmt.Fprintln(w, strings.Join(user.Attributes(), "\t"))
@@ -46,6 +47,7 @@ func (u *User) Attributes() []string {
 	return []string{
 		u.LoginName,
 		u.GitHubUsername,
+		u.SlackUsername,
 		u.SlackMention(),
 	}
 }

--- a/models/user.go
+++ b/models/user.go
@@ -27,7 +27,7 @@ func NewUser(loginName string, githubUsername string, slackUsername string, slac
 	}
 }
 
-var UserHeaders = []string{
+var userHeaders = []string{
 	"AWS-IAM",
 	"GITHUB",
 	"SLACK",
@@ -36,7 +36,7 @@ var UserHeaders = []string{
 
 func PrintUsers(users []*User) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, strings.Join(UserHeaders, "\t"))
+	fmt.Fprintln(w, strings.Join(userHeaders, "\t"))
 	for _, user := range users {
 		fmt.Fprintln(w, strings.Join(user.Attributes(), "\t"))
 	}


### PR DESCRIPTION
## WHY

from [List command should return users in a table format](https://github.com/wantedly/developers-account-mapper/issues/25)
> We should consider some format that both humans and programs can parse easily.

## WHAT

List command prints users in a table format.

```console
potsbo@magi-INS-% make
go build -ldflags="-s -w -X \"main.Version=v0.2.0\" -X \"main.GitCommit=8895907\"" -o bin/developers-account-mapper
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper list
AWS-IAM  GITHUB  SLACK    SLACK_MENTION
shimpei  potsbo  shimpei  <@XXXXXXXXX|shimpei>
potsbo@magi-INS-% envchain wtd bin/developers-account-mapper list | awk '{ print $1, $4 }'
AWS-IAM SLACK_MENTION
shimpei <@XXXXXXXXX|shimpei>
```

@dtan4 
Actually, I don't know this structure is right to do this.
Currently, `list` command fetches `users` from `DynamoDB`, pass it to `models.User` and let print.
Do you think `models.User` should handle `DynamoDB` stuff?
I'm considering Rails architecture, in which models handle ActiveRecord.