### PR TITLE
[PENDING] Add Stdin

### DIFF
--- a/command/exec.go
+++ b/command/exec.go
@@ -43,6 +43,7 @@ func (c *ExecCommand) Run(args []string) int {
 	execCmd.Env = envs
 	execCmd.Stderr = os.Stderr
 	execCmd.Stdout = os.Stdout
+	execCmd.Stdin = os.Stdin
 	err = execCmd.Run()
 
 	if execCmd.Process == nil {


### PR DESCRIPTION
## WHY

`envchain wtd developers-account-mapper exec shimpei rails c` doest not start `rails console`, because Stdin not specified.

## WHAT

Add stdin

## TEST

### tty like commands now work
```console
potsbo@quorra-INS-% envchain wtd developers-account-mapper exec shimpei rails c
Running via Spring preloader in process 31821
Loading development environment (Rails 4.1.14.2)
[1] pry(main)>
```
### normal commands still work fine
```console
potsbo@quorra-INS-% envchain wtd developers-account-mapper exec shimpei ls
Applications		Develop			Downloads		Library			Music			Public			data
Desktop			Documents		Dropbox			Movies			Pictures		WebstormProjects	src
```