### PR TITLE
Add to-slack-mention command

### DIFF
--- a/command/to-github-name.go
+++ b/command/to-github-name.go
@@ -3,7 +3,6 @@ package command
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/wantedly/developers-account-mapper/store"
@@ -15,9 +14,7 @@ type ToGithubNameCommand struct {
 
 func (c *ToGithubNameCommand) Run(args []string) int {
 	var loginName string
-	if len(args) == 0 {
-		loginName = os.Getenv("USER")
-	} else if len(args) == 1 {
+	if len(args) == 1 {
 		loginName = args[0]
 	} else {
 		log.Println(c.Help())

--- a/command/to-slack-mention.go
+++ b/command/to-slack-mention.go
@@ -1,0 +1,48 @@
+package command
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/wantedly/developers-account-mapper/store"
+)
+
+type ToSlackMention struct {
+	Meta
+}
+
+func (c *ToSlackMention) Run(args []string) int {
+	var loginName string
+	if len(args) == 0 {
+		loginName = os.Getenv("USER")
+	} else if len(args) == 1 {
+		loginName = args[0]
+	} else {
+		log.Println(c.Help())
+		return 1
+	}
+
+	s := store.NewDynamoDB()
+
+	user, err := s.GetUserByLoginName(loginName)
+	if err != nil {
+		log.Println(err)
+		return 1
+	}
+	fmt.Printf("SlackMention account for %s is: %s\n", loginName, user.SlackMention())
+
+	return 0
+}
+
+func (c *ToSlackMention) Synopsis() string {
+	return "Get <slack_mention> from <login_name>"
+}
+
+func (c *ToSlackMention) Help() string {
+	helpText := `
+
+`
+	return strings.TrimSpace(helpText)
+}

--- a/command/to-slack-mention.go
+++ b/command/to-slack-mention.go
@@ -3,7 +3,6 @@ package command
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/wantedly/developers-account-mapper/store"
@@ -15,9 +14,7 @@ type ToSlackMention struct {
 
 func (c *ToSlackMention) Run(args []string) int {
 	var loginName string
-	if len(args) == 0 {
-		loginName = os.Getenv("USER")
-	} else if len(args) == 1 {
+	if len(args) == 1 {
 		loginName = args[0]
 	} else {
 		log.Println(c.Help())

--- a/commands.go
+++ b/commands.go
@@ -32,6 +32,11 @@ func Commands(meta *command.Meta) map[string]cli.CommandFactory {
 				Meta: *meta,
 			}, nil
 		},
+		"to-slack-mention": func() (cli.Command, error) {
+			return &command.ToSlackMention{
+				Meta: *meta,
+			}, nil
+		},
 
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{


### PR DESCRIPTION
## WHY

Sometimes `exec` command is too much to use when we just want to get `slack-mention`.

##

Add `to-slack-mention` command to get `slack-mention`