### PR TITLE
Bump up to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.2.1](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.2.1) (2017-01-23)
+## [v0.2.1](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.2.1) (2017-01-23)
 
 [Add to-slack-mention command](https://github.com/wantedly/developers-account-mapper/pull/30)
 
@@ -14,7 +14,7 @@
 
 [Fix version command](https://github.com/wantedly/developers-account-mapper/pull/26)
 
-## [0.2.0](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.2.0) (2017-01-16)
+## [v0.2.0](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.2.0) (2017-01-16)
 
 ### Added
 
@@ -25,7 +25,7 @@
 - [Accept only expected number of arguments](https://github.com/wantedly/developers-account-mapper/pull/19)
 - [Use same user summary format as register](https://github.com/wantedly/developers-account-mapper/pull/21)
 
-## [0.1.0](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.1.0) (2017-01-12)
+## [v0.1.0](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.1.0) (2017-01-12)
 
 Initial release
 　

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [0.2.1](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.2.1) (2017-01-23)
+
+[Add to-slack-mention command](https://github.com/wantedly/developers-account-mapper/pull/30)
+
+## Added
+
+[Add SLACK\_USER env var in exec command](https://github.com/wantedly/developers-account-mapper/pull/27)
+
+## Changed
+
+[List prints with tab](https://github.com/wantedly/developers-account-mapper/pull/28)
+
+## Fixed
+
+[Fix version command](https://github.com/wantedly/developers-account-mapper/pull/26)
+
 ## [0.2.0](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.2.0) (2017-01-16)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,17 @@
 ## [v0.2.1](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.2.1) (2017-01-23)
 
-[Add to-slack-mention command](https://github.com/wantedly/developers-account-mapper/pull/30)
-
 ## Added
 
-[Add SLACK\_USER env var in exec command](https://github.com/wantedly/developers-account-mapper/pull/27)
+- [Add to-slack-mention command](https://github.com/wantedly/developers-account-mapper/pull/30)
+- [Add SLACK\_USER env var in exec command](https://github.com/wantedly/developers-account-mapper/pull/27)
 
 ## Changed
 
-[List prints with tab](https://github.com/wantedly/developers-account-mapper/pull/28)
+- [List prints with tab](https://github.com/wantedly/developers-account-mapper/pull/28)
 
 ## Fixed
 
-[Fix version command](https://github.com/wantedly/developers-account-mapper/pull/26)
+- [Fix version command](https://github.com/wantedly/developers-account-mapper/pull/26)
 
 ## [v0.2.0](https://github.com/wantedly/developers-account-mapper/releases/tag/v0.2.0) (2017-01-16)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME           := developers-account-mapper
-VERSION        := v0.2.0
+VERSION        := v0.2.1
 REVISION       := $(shell git rev-parse --short HEAD)
 
 SRCS           := $(shell find . -type f -name '*.go')


### PR DESCRIPTION
## Added

- [Add to-slack-mention command](https://github.com/wantedly/developers-account-mapper/pull/30)
- [Add SLACK\_USER env var in exec command](https://github.com/wantedly/developers-account-mapper/pull/27)

## Changed

- [List prints with tab](https://github.com/wantedly/developers-account-mapper/pull/28)

## Fixed

- [Fix version command](https://github.com/wantedly/developers-account-mapper/pull/26)

## TODO
`make release` after merged