### PR TITLE
Simple output for to-* commands

### DIFF
--- a/command/to-github-name.go
+++ b/command/to-github-name.go
@@ -28,7 +28,7 @@ func (c *ToGithubNameCommand) Run(args []string) int {
 		log.Println(err)
 		return 1
 	}
-	fmt.Printf("GitHub account for %s is: %s\n", loginName, user.GitHubUsername)
+	fmt.Println(user.GitHubUsername)
 
 	return 0
 }

--- a/command/to-slack-mention.go
+++ b/command/to-slack-mention.go
@@ -28,7 +28,7 @@ func (c *ToSlackMention) Run(args []string) int {
 		log.Println(err)
 		return 1
 	}
-	fmt.Printf("SlackMention account for %s is: %s\n", loginName, user.SlackMention())
+	fmt.Println(user.SlackMention())
 
 	return 0
 }


### PR DESCRIPTION
## WHY

`to-github-name` and `to-slack-mention` have to return in a format that programs can parse easily.
Verbose information can be taken care in list command.
## WHAT

Returns only the result.