### PR TITLE
Add docker as a service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: required
+services:
+  - docker
 language: go
 go:
   - '1.7'


### PR DESCRIPTION
## WHY
Travis failed because `docker` was not found.
```console
docker build -t quay.io/wantedly/developers-account-mapper:latest .
make: docker: Command not found
make: *** [docker-build] Error 127
```
https://docs.travis-ci.com/user/docker/ says adding docker as a service will solve this.

## WHAT

Add docker as a service