### PR TITLE
Inject Slack API token from out of slack package

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -65,7 +65,12 @@ func (u *User) SlackMention() string {
 }
 
 func (u *User) RetrieveSlackUserId() error {
-	nameIdMap, err := services.SlackUserList()
+	token := os.Getenv("SLACK_API_TOKEN")
+	if token == "" {
+		return fmt.Errorf("You need to pass SLACK_API_TOKEN as environment variable")
+	}
+
+	nameIdMap, err := services.SlackUserList(token)
 	if err != nil {
 		return err
 	}

--- a/services/slack_api.go
+++ b/services/slack_api.go
@@ -2,9 +2,7 @@ package services
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 
 	"github.com/jmoiron/jsonq"
@@ -14,11 +12,7 @@ const (
 	slackUserListURL = "https://slack.com/api/users.list"
 )
 
-func SlackUserList() (map[string]string, error) {
-	token := os.Getenv("SLACK_API_TOKEN")
-	if token == "" {
-		return nil, fmt.Errorf("You need to pass SLACK_API_TOKEN as environment variable")
-	}
+func SlackUserList(token string) (map[string]string, error) {
 	requestURL := slackUserListURL + "?token=" + token
 	resp, err := http.Get(requestURL)
 	if err != nil {


### PR DESCRIPTION
## WHY

Currently `SlackUserList` retrieves Slack API key from environment variable. It's hard to write unit test.

## WHA

Inject Slack API token as method argument.