### PR TITLE
Build with Go 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 language: go
 go:
-  - '1.7'
+  - '1.9.3'
 before_install:
   - sudo add-apt-repository ppa:masterminds/glide -y
   - sudo apt-get update -q
@@ -25,17 +25,14 @@ deploy:
     file: 'dist/*.{tar.gz,zip}'
     on:
       tags: true
-      go: '1.7'
   - provider: script
     skip_cleanup: true
     script: make ci-docker-release
     on:
       branch: master
-      go: '1.7'
   - provider: script
     skip_cleanup: true
     script: DOCKER_IMAGE_TAG=$TRAVIS_TAG make ci-docker-release
     on:
       tags: true
       branch: master
-      go: '1.7'


### PR DESCRIPTION
## WHY

Go 1.9 was released in 2017 summer. Now Go 1.7 is no longer supported.

## WHAT

Test and build with the newest Golang.