### PR TITLE
Add test for SlackUserList

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,9 +75,15 @@
   packages = ["unix"]
   revision = "a60af9cbbc6ab800af4f2be864a31f423a0ae1f2"
 
+[[projects]]
+  name = "gopkg.in/h2non/gock.v1"
+  packages = ["."]
+  revision = "26775f23aa9da4cbd47bc2600a57ac07bbf3bd20"
+  version = "v1.0.7"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f88a7f08d3399c75c4613719ecefdd97f29902f6c94e1e05d140d9916d0c3737"
+  inputs-digest = "055bab2a6eb61fe7d341ccbd7a1a40d3fbdeb0952a2b1ec282eaba4614120733"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,3 +36,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "gopkg.in/h2non/gock.v1"
+  version = "1.0.7"

--- a/services/slack_api_test.go
+++ b/services/slack_api_test.go
@@ -1,0 +1,114 @@
+package services
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestSlackUserList(t *testing.T) {
+	defer gock.Off()
+
+	// sample response was copied from https://api.slack.com/methods/users.list
+	gock.New("https://slack.com").Get("/api/users.list").MatchParam("token", "testtoken").Reply(200).BodyString(`{
+    "ok": true,
+    "members": [
+        {
+            "id": "W012A3CDE",
+            "team_id": "T012AB3C4",
+            "name": "spengler",
+            "deleted": false,
+            "color": "9f69e7",
+            "real_name": "spengler",
+            "tz": "America\/Los_Angeles",
+            "tz_label": "Pacific Daylight Time",
+            "tz_offset": -25200,
+            "profile": {
+                "avatar_hash": "ge3b51ca72de",
+                "status_text": "Print is dead",
+                "status_emoji": ":books:",
+                "real_name": "Egon Spengler",
+                "display_name": "spengler",
+                "real_name_normalized": "Egon Spengler",
+                "display_name_normalized": "spengler",
+                "email": "spengler@ghostbusters.example.com",
+                "image_24": "https:\/\/...\/avatar\/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_32": "https:\/\/...\/avatar\/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_48": "https:\/\/...\/avatar\/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_72": "https:\/\/...\/avatar\/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_192": "https:\/\/...\/avatar\/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "image_512": "https:\/\/...\/avatar\/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+                "team": "T012AB3C4"
+            },
+            "is_admin": true,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": false,
+            "updated": 1502138686,
+            "is_app_user": false,
+            "has_2fa": false
+        },
+        {
+            "id": "W07QCRPA4",
+            "team_id": "T0G9PQBBK",
+            "name": "glinda",
+            "deleted": false,
+            "color": "9f69e7",
+            "real_name": "Glinda Southgood",
+            "tz": "America\/Los_Angeles",
+            "tz_label": "Pacific Daylight Time",
+            "tz_offset": -25200,
+            "profile": {
+                "avatar_hash": "8fbdd10b41c6",
+                "image_24": "https:\/\/a.slack-edge.com...png",
+                "image_32": "https:\/\/a.slack-edge.com...png",
+                "image_48": "https:\/\/a.slack-edge.com...png",
+                "image_72": "https:\/\/a.slack-edge.com...png",
+                "image_192": "https:\/\/a.slack-edge.com...png",
+                "image_512": "https:\/\/a.slack-edge.com...png",
+                "image_1024": "https:\/\/a.slack-edge.com...png",
+                "image_original": "https:\/\/a.slack-edge.com...png",
+                "first_name": "Glinda",
+                "last_name": "Southgood",
+                "title": "Glinda the Good",
+                "phone": "",
+                "skype": "",
+                "real_name": "Glinda Southgood",
+                "real_name_normalized": "Glinda Southgood",
+                "display_name": "Glinda the Fairly Good",
+                "display_name_normalized": "Glinda the Fairly Good",
+                "email": "glenda@south.oz.coven"
+            },
+            "is_admin": true,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": false,
+            "updated": 1480527098,
+            "has_2fa": false
+        }
+    ],
+    "cache_ts": 1498777272,
+    "response_metadata": {
+        "next_cursor": "dXNlcjpVMEc5V0ZYTlo="
+    }
+}
+`)
+
+	got, err := SlackUserList("testtoken")
+	if err != nil {
+		t.Errorf("got error: %s", err)
+	}
+
+	want := map[string]string{
+		"spengler": "W012A3CDE",
+		"glinda":   "W07QCRPA4",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("want: %#v, got: %#v", want, got)
+	}
+}


### PR DESCRIPTION
## WHY

I'd like to modify the behavior of `SlackUserList` to use `display_name` field.
Now there is no test for this method, so I (we) cannot validate the correct behavior before-and-after.

## WHAT

Write a unit test for `SlackUserList`, which mocks the Slack API server response.